### PR TITLE
Fixed name and current chat channel display in chatbox

### DIFF
--- a/src/main/java/codepanter/anotherbronzemanmode/AnotherBronzemanModePlugin.java
+++ b/src/main/java/codepanter/anotherbronzemanmode/AnotherBronzemanModePlugin.java
@@ -906,7 +906,7 @@ public class AnotherBronzemanModePlugin extends Plugin
         if (player != null)
         {
             Widget chatboxInput = client.getWidget(ComponentID.CHATBOX_INPUT);
-            String namePlusChannel = "";
+            String namePlusChannel = player.getName();
             if (chatboxInput != null)
             {
                 String text = chatboxInput.getText();

--- a/src/main/java/codepanter/anotherbronzemanmode/AnotherBronzemanModePlugin.java
+++ b/src/main/java/codepanter/anotherbronzemanmode/AnotherBronzemanModePlugin.java
@@ -905,7 +905,18 @@ public class AnotherBronzemanModePlugin extends Plugin
         Player player = client.getLocalPlayer();
         if (player != null)
         {
-            return getNameWithIcon(bronzemanIconOffset, player.getName());
+            Widget chatboxInput = client.getWidget(ComponentID.CHATBOX_INPUT);
+            String namePlusChannel = "";
+            if (chatboxInput != null)
+            {
+                String text = chatboxInput.getText();
+                int idx = text.indexOf(':');
+                if (idx != -1)
+                {
+                    namePlusChannel = text.substring(0,idx);
+                }
+            }
+            return getNameWithIcon(bronzemanIconOffset, namePlusChannel);
         }
         return null;
     }


### PR DESCRIPTION
When the plugin adds the Bronzeman icon to the chatbox name, it overrides everything before the `:` in the chatbox. This includes the current chat channel that gets displayed if the `Chatbox Mode - Set Automatically` setting is enabled from the in-game settings.

**What the default chatbox name looks like without the plugin enabled**
![image](https://github.com/user-attachments/assets/bedd542d-d273-4972-8b03-094efda67adb)


**When you enable the plugin, it overrides the chatbox name as shown:**
![image](https://github.com/user-attachments/assets/c958f69c-6880-4c18-993d-ea1b93387adf)

This PR fixes this behavior by getting the full name text, including current chat channel, then appending the bronzeman icon to that. 
**New behavior:**
![image](https://github.com/user-attachments/assets/0c328cb4-a12b-4807-894c-4b13bef051ec)
