### PR TITLE
Add GE location check to kill search results

### DIFF
--- a/src/main/java/codepanter/anotherbronzemanmode/AnotherBronzemanModePlugin.java
+++ b/src/main/java/codepanter/anotherbronzemanmode/AnotherBronzemanModePlugin.java
@@ -94,6 +94,7 @@ public class AnotherBronzemanModePlugin extends Plugin
     private static final String BM_BACKUP_STRING = "!bmbackup";
 
     private static final int GE_SEARCH_BUILD_SCRIPT = 751;
+    private static final int GE_REGION_ID = 12598;
 
     private boolean LOGGING_IN = false;
 
@@ -555,6 +556,11 @@ public class AnotherBronzemanModePlugin extends Plugin
 
     void killSearchResults()
     {
+        if (client.getLocalPlayer().getWorldLocation().getRegionID() != GE_REGION_ID)
+        {
+            return;
+        }
+
         Widget grandExchangeSearchResults = client.getWidget(ComponentID.CHATBOX_GE_SEARCH_RESULTS);
 
         if (grandExchangeSearchResults == null)


### PR DESCRIPTION
It's a bit hacky, but this will unblock mermaid riddles (see #34) and any other future content that uses the same GE_SEARCH_BUILD_SCRIPT (as long as it's not in the vicinity of the GE). 

Mermaid answer enabled:
<img width="808" height="310" alt="Screenshot 2026-01-31 170622" src="https://github.com/user-attachments/assets/45243d3e-95e2-4d83-ab04-bb77c1a05385" />

GE purchase still blocked:
<img width="977" height="506" alt="Screenshot 2026-01-31 170932" src="https://github.com/user-attachments/assets/603fc2b7-0ba9-4ddf-90a0-083a214317b3" />
